### PR TITLE
Stop appendReplacement from throwing an exception when a replacement group is null.

### DIFF
--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -366,7 +366,10 @@ public final class Matcher {
           if (n > groupCount) {
             throw new IndexOutOfBoundsException("n > number of groups: " + n);
           }
-          sb.append(substring(start(n), end(n)));
+          String group = group(n);
+          if (group != null) {
+            sb.append(group);
+          }
           last = i;
           i--;
           continue;

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -293,6 +293,38 @@ public class MatcherTest {
         "zzfoo", buffer.toString());
   }
 
+  @Test
+  public void testEmptyReplacementGroups() {
+    StringBuffer buffer = new StringBuffer();
+    Matcher matcher = Pattern.compile("(a)(b$)?(b)?").matcher("abc");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1-$2-$3");
+    assertEquals("a--b", buffer.toString());
+    matcher.appendTail(buffer);
+    assertEquals("a--bc", buffer.toString());
+
+    buffer = new StringBuffer();
+    matcher = Pattern.compile("(a)(b$)?(b)?").matcher("ab");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1-$2-$3");
+    matcher.appendTail(buffer);
+    assertEquals("a-b-", buffer.toString());
+
+    buffer = new StringBuffer();
+    matcher = Pattern.compile("(^b)?(b)?c").matcher("abc");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1-$2");
+    matcher.appendTail(buffer);
+    assertEquals("a-b", buffer.toString());
+
+    buffer = new StringBuffer();
+    matcher = Pattern.compile("^(.)[^-]+(-.)?(.*)").matcher("Name");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1$2");
+    matcher.appendTail(buffer);
+    assertEquals("N", buffer.toString());
+  }
+
   // This example is documented in the com.google.re2j package.html.
   @Test
   public void testDocumentedExample() {


### PR DESCRIPTION
See bug 24605755.