### PR TITLE
Optimize multithreading performance of RE2J

### DIFF
--- a/java/com/google/re2j/Machine.java
+++ b/java/com/google/re2j/Machine.java
@@ -95,7 +95,7 @@ class Machine {
   }
 
   // Corresponding compiled regexp.
-  private RE2 re2;
+  private final RE2 re2;
 
   // Compiled program.
   private final Prog prog;
@@ -105,7 +105,7 @@ class Machine {
 
   // pool of available threads
   // Really a stack:
-  private List<Thread> pool = new ArrayList<Thread>();
+  private final List<Thread> pool = new ArrayList<Thread>();
 
   // Whether a match was found.
   private boolean matched;

--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -59,15 +59,6 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Releases memory used by internal caches associated with this pattern. Does
-   * not change the observable behaviour. Useful for tests that detect memory
-   * leaks via allocation tracking.
-   */
-  public void reset() {
-    re2.reset();
-  }
-
-  /**
    * Returns the flags used in the constructor.
    */
   public int flags() {


### PR DESCRIPTION
Hi Alan, 

We have put up this pull request for multithreading performance fixes.
We noticed that the contention overhead for RE2.get() function that returns 
Machine objects from the Machine cache is  greater than 
the slowdown that may have been created by instantiating newer Machine objects. 

To illustrate: the test case when we noticed this was in a scenario with Presto (database 
that queries hive data) where 128 concurrent threads were using RE2 library at a time. Over the 
lifetime of a regular expression query, a single process calls pattern.matcher() and matcher.find() 
more than a million times. All these calls are made by multiple threads (128) at a time. 

We noticed that when removing the machine cache, time taken by a regular expression query 
dropped down to 10min from 40min when using the machine cache. We verified this 
with/without the machine cache and also used yourkit profiler. All types of regular 
expression queries performed faster. 

This change has no effect on programs that use single thread. Additionally, we have 
also put two small changes in this pull request which are mostly minor optimizations. 

To summarize, this pull request attempts to: 
1. remove machine cache to avoid contention when retrieving cached machine objects
2. use array of Inst objects in Prog to optimize faster access to compiled Insts
3. declare RE2 and threadpool as final in Machine.java

Let us know your comments. Rebecca had also briefly discussed these improvements here:  https://groups.google.com/forum/#!topic/re2j-discuss/3iEzpgxiI4k

