### PR TITLE
fix condition incorrectly ported from Go

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -1495,7 +1495,7 @@ class Parser {
     String name = cls.substring(0, i + 2);  // "[:alnum:]"
     t.skipString(name);
     CharGroup g = CharGroup.POSIX_GROUPS.get(name);
-    if (g.sign == 0) {
+    if (g == null) {
       throw new PatternSyntaxException(ERR_INVALID_CHAR_RANGE, name);
     }
     cc.appendGroup(g, (flags & RE2.FOLD_CASE) != 0);


### PR DESCRIPTION
The original Go code reads:

    g := posixGroup[name]
    if g.sign == 0 { ... }

The condition is true if the map lookup failed; there are no actual map values for which sign != 0.