### PR TITLE
Fix range of make_Cc

### DIFF
--- a/java/com/google/re2j/UnicodeTables.java
+++ b/java/com/google/re2j/UnicodeTables.java
@@ -1629,7 +1629,7 @@ class UnicodeTables {
   private static final int[][] _Cc = make_Cc();
   private static int[][] make_Cc() {
     return new int[][] {
-		{0x0001, 0x001f, 1},
+		{0x0000, 0x001f, 1},
 		{0x007f, 0x009f, 1},
     };
   }


### PR DESCRIPTION
'Cc' of Unicode character class must be contains NULL character(0x000), 
But current code isn't contains it.
http://www.fileformat.info/info/unicode/category/Cc/list.htm

In java.util.regex.Pattern The Cc pattern is correctly implemented.