### PR TITLE
use a open addressing map to store folding paths

### DIFF
--- a/javatests/com/google/re2j/RunesTest.java
+++ b/javatests/com/google/re2j/RunesTest.java
@@ -1,0 +1,48 @@
+package com.google.re2j;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RunesTest {
+
+    @Test
+    public void testRunes() {
+        RE2 compile = RE2.compile("[0-13-46-78-9b-ce-fh-i]");
+        assertTrue(compile.match("0"));
+        assertTrue(compile.match("1"));
+        assertTrue(compile.match("3"));
+        assertTrue(compile.match("4"));
+        assertTrue(compile.match("6"));
+        assertTrue(compile.match("7"));
+        assertTrue(compile.match("8"));
+        assertTrue(compile.match("9"));
+        assertTrue(compile.match("b"));
+        assertTrue(compile.match("c"));
+        assertTrue(compile.match("e"));
+        assertTrue(compile.match("f"));
+        assertTrue(compile.match("h"));
+        assertTrue(compile.match("i"));
+        
+        assertFalse(compile.match("2"));
+        assertFalse(compile.match("5"));
+        assertFalse(compile.match("a"));
+        assertFalse(compile.match("d"));
+        assertFalse(compile.match("g"));
+        assertFalse(compile.match("j"));
+    }
+    @Test
+    public void testRunesWithFold() {
+        Pattern pattern = Pattern.compile("ak", Pattern.CASE_INSENSITIVE);
+        String upperCase = "AK";
+        String withKelvin = "AK";
+        assertFalse(withKelvin.equals(upperCase));// check we use the kelvin sign 
+        
+        assertTrue(pattern.matches("ak"));
+        assertTrue(pattern.matches(upperCase));
+        assertTrue(pattern.matches("aK"));
+        assertTrue(pattern.matches("Ak"));
+        assertTrue(pattern.matches(withKelvin));
+    }
+}

--- a/javatests/com/google/re2j/UnicodeTest.java
+++ b/javatests/com/google/re2j/UnicodeTest.java
@@ -4,6 +4,7 @@
 
 package com.google.re2j;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -38,4 +39,24 @@ public class UnicodeTest {
   // int toLower(int r);
   // int simpleFold(int r);
 
+  @Test
+  public void testOptimizedFold() {
+    // check that the new optimized fold alg will have the same result as using simple fold
+    for (int i = 0; i <= Unicode.MAX_RUNE; i++) {
+      int[] orbit = Unicode.optimizedFoldOrbit(i);
+      if (orbit != null) {
+        int r = Unicode.simpleFold(i);
+        int j = 0;
+        while (r != i) {
+          assertEquals(r, orbit[j]);
+          j++;
+          r = Unicode.simpleFold(r);
+        }
+      } else {
+        int r = Unicode.simpleFold(i);
+        assertEquals(r, Unicode.optimizedFoldNonOrbit(i)); // first fold map the same
+        assertEquals(i, Unicode.simpleFold(r)); // second fold always go back to first
+      }
+    }
+  }
 }


### PR DESCRIPTION
 - change simplefold logic to use an open addressing map with phi mix hashing. 
     - quick path check of value if < ORBIT_MIN_VALUE
     - if there is a folding array just iterate over avoiding continuous lookup
     - if not just got through toUpper toLower path
 - reduce binary search to exclude the element searched through the linear searched

This optimisation came from profiling my app with real payload, the simpleFold was taking around 15% cpu and is now negligible.

I added  a few test to verify that the logic is still working as expected.