### PR TITLE
Use a ThreadLocal instead a synchronization mechanism

### DIFF
--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -58,15 +58,6 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Releases memory used by internal caches associated with this pattern. Does
-   * not change the observable behaviour. Useful for tests that detect memory
-   * leaks via allocation tracking.
-   */
-  public void reset() {
-    re2.reset();
-  }
-
-  /**
    * Returns the flags used in the constructor.
    */
   public int flags() {


### PR DESCRIPTION
This showed in the profile as a big time consumer. I initially removed
the whole pooling and it was 30% faster.

I tested the memory footprint and was 5 extra allocations per op:

 1 for Machine, 2 for Queue, and 2 for Queue.Entry.

So instead I used a ThreadLocal of Machine. This is the same
optimization that Teradata fork does: https://github.com/Teradata/re2j

I also removed the reset method since it is not used and doesn't make
sense after this change.