### PR TITLE
Restore Pattern.reset() method

### DIFF
--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -58,6 +58,15 @@ public final class Pattern implements Serializable {
   }
 
   /**
+   * Releases current thread memory used by internal caches associated with this pattern. Does
+   * not change the observable behaviour. Useful for tests that detect memory
+   * leaks via allocation tracking.
+   */
+  public void reset() {
+    re2.reset();
+  }
+
+  /**
    * Returns the flags used in the constructor.
    */
   public int flags() {

--- a/java/com/google/re2j/RE2.java
+++ b/java/com/google/re2j/RE2.java
@@ -204,6 +204,11 @@ class RE2 {
     return re2;
   }
 
+  // Clears the memory associated with this machine for the current thread.
+  void reset() {
+    machineThreadLocal.remove();
+  }
+
   /**
    * Returns the number of parenthesized subexpressions in this regular
    * expression.


### PR DESCRIPTION
This method was part of the Pattern API.

Now it doesn't clean all the threds but just the current thread,
since the ThreadLocal doesn't allow us to access the rest of
threads.