### PR TITLE
Rollback of ThreadLocal optimization change

### DIFF
--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -58,7 +58,7 @@ public final class Pattern implements Serializable {
   }
 
   /**
-   * Releases current thread memory used by internal caches associated with this pattern. Does
+   * Releases memory used by internal caches associated with this pattern. Does
    * not change the observable behaviour. Useful for tests that detect memory
    * leaks via allocation tracking.
    */

--- a/java/com/google/re2j/RE2.java
+++ b/java/com/google/re2j/RE2.java
@@ -110,8 +110,8 @@ class RE2 {
   int prefixRune;               // first rune in prefix
 
   // Cache of machines for running regexp.
-  // Warning: Don't use initialValue, GWT doesn't have that method.
-  private final ThreadLocal<Machine> machineThreadLocal = new ThreadLocal<Machine>();
+  // Accesses must be serialized using |this| monitor.
+  private final List<Machine> machine = new ArrayList<Machine>();
 
   // This is visible for testing.
   RE2(String expr) {
@@ -199,17 +199,35 @@ class RE2 {
     return re2;
   }
 
-  // Clears the memory associated with this machine for the current thread.
-  void reset() {
-    machineThreadLocal.remove();
-  }
-
   /**
    * Returns the number of parenthesized subexpressions in this regular
    * expression.
    */
   int numberOfCapturingGroups() {
     return numSubexp;
+  }
+
+  // get() returns a machine to use for matching |this|.  It uses |this|'s
+  // machine cache if possible, to avoid unnecessary allocation.
+  synchronized Machine get() {
+    int n = machine.size();
+    if (n > 0) {
+      return machine.remove(n - 1);
+    }
+    return new Machine(this);
+  }
+
+  // Clears the memory associated with this machine.
+  synchronized void reset() {
+    machine.clear();
+  }
+
+  // put() returns a machine to |this|'s machine cache.  There is no attempt to
+  // limit the size of the cache, so it will grow to the maximum number of
+  // simultaneous matches run using |this|.  (The cache empties when |this|
+  // gets garbage collected.)
+  synchronized void put(Machine m) {
+    machine.add(m);
   }
 
   @Override
@@ -221,13 +239,11 @@ class RE2 {
   // the position of its subexpressions.
   // Derived from exec.go.
   private int[] doExecute(MachineInput in, int pos, int anchor, int ncap) {
-    Machine m = machineThreadLocal.get();
-    if (m == null) {
-      m = new Machine(this);
-      machineThreadLocal.set(m);
-    }
+    Machine m = get();
     m.init(ncap);
-    return m.match(in, pos, anchor) ? m.submatches() : null;
+    int[] cap = m.match(in, pos, anchor) ? m.submatches() : null;
+    put(m);
+    return cap;
   }
 
   /**


### PR DESCRIPTION
This change rollsback 3def69665, 7597ac7e5cf and f6ab6e0b99 due to an
internal (Google) memory regression.

The cause is a memory leak because of a non-static ThreadLocal usage that contained references to the object instance itself (Machine -> RE2 objects).

The main issue is creating unbound new ThreadLocal instances leaks ThreadLocals since they are not GCed.

The repro case is much easier:

```
public class Main {
  public static void main(String[] args) {
    for (int i = 0; i < 10000000; i++) {
      Pattern.compile("aaaa").matches("aaaa");
    }
  }
}
```

What is happening here?

Each Pattern.compile is creating a new RE2 instance. Each RE2 instance is creating its own ThreadLocal.

When we use the ThreadLocal we access a per thread map ThreadLocalMap. This map contains Entries with ThreadLocal as key and the value as the value.

The Entry of the map (ThreadLocalMap.Entry) extend WeakReference. And here is the problem. The entry itself is not weak. It is just the key that is weak.

So we are essentially creating thousands of entries on that map using the a different ThreadLocal as a key each time.

Why are not GCed? The ThreadLocal is not longer referenced, right? It is referenced:

Each Entry on that map (That is not weak, remember, it is just the key that is weak) contains a value that is...The Machine. Machine points to RE2...and RE2 class points to the ThreadLocal!. And there we have the cycle.

TL;DR: Never create unbound number of ThreadLocals. If not static, make sure that the number of instances are controlled (IOW, not unbound).

But does this mean that ThreadLocals are never GCed from the ThreadLocalMap?

No

When we look for a ThreadLocal in the ThreadLocalMap (by doing threadLocal.get() for example), if we don't find the ThreadLocal in the map by doing a simple hashcode lookup in a array, it calls getEntryAfterMiss.This method calls expungeStaleEntry if Entry.get() returns null (it is the week reference to the key, the threadLocal). This code (and also other places that end up calling expungeStaleEntry)  cleanups the stale entry if the threadlocal has been GCed.

But in this case it wasn't GCed, because the value is an indirect reference to the ThreadLocal (because it is a non-static member of RE2).
