### PR TITLE
Add StringBuilder overloads of Matcher methods

### DIFF
--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -334,7 +334,7 @@ public final class Matcher {
    * to the beginning of the most recent match, and then the replacement with
    * submatch groups substituted for references of the form {@code $n}, where
    * {@code n} is the group number in decimal.  It advances the append position
-   * to the position where the most recent match ended.
+   * to where the most recent match ended.
    *
    * <p>To embed a literal {@code $}, use \$ (actually {@code "\\$"} with string
    * escapes).  The escape is only necessary when {@code $} is followed by a
@@ -352,13 +352,54 @@ public final class Matcher {
    * @throws IllegalStateException if there was no most recent match
    * @throws IndexOutOfBoundsException if replacement refers to an invalid group
    */
-  public Matcher appendReplacement(StringBuffer sb, String replacement) {
+  public Matcher appendReplacement(StringBuffer sb, String replacement)  {
     int s = start();
     int e = end();
     if (appendPos < s) {
       sb.append(substring(appendPos, s));
     }
     appendPos = e;
+    StringBuilder result = new StringBuilder();
+    appendReplacementInternal(result, replacement);
+    sb.append(result);
+    return this;
+  }
+
+  /**
+   * Appends to {@code sb} two strings: the text from the append position up
+   * to the beginning of the most recent match, and then the replacement with
+   * submatch groups substituted for references of the form {@code $n}, where
+   * {@code n} is the group number in decimal.  It advances the append position
+   * to where the most recent match ended.
+   *
+   * <p>To embed a literal {@code $}, use \$ (actually {@code "\\$"} with string
+   * escapes).  The escape is only necessary when {@code $} is followed by a
+   * digit, but it is always allowed.  Only {@code $} and {@code \} need
+   * escaping, but any character can be escaped.
+   *
+   * <p>The group number {@code n} in {@code $n} is always at least one digit
+   * and expands to use more digits as long as the resulting number is a
+   * valid group number for this pattern.  To cut it off earlier, escape the
+   * first digit that should not be used.
+   *
+   * @param sb the {@link StringBuilder} to append to
+   * @param replacement the replacement string
+   * @return the {@code Matcher} itself, for chained method calls
+   * @throws IllegalStateException if there was no most recent match
+   * @throws IndexOutOfBoundsException if replacement refers to an invalid group
+   */
+  public Matcher appendReplacement(StringBuilder sb, String replacement) {
+    int s = start();
+    int e = end();
+    if (appendPos < s) {
+      sb.append(substring(appendPos, s));
+    }
+    appendPos = e;
+    appendReplacementInternal(sb, replacement);
+    return this;
+  }
+
+  private void appendReplacementInternal(StringBuilder sb, String replacement) {
     int last = 0;
     int i = 0;
     int m = replacement.length();
@@ -401,7 +442,6 @@ public final class Matcher {
     if (last < m) {
       sb.append(replacement.substring(last, m));
     }
-    return this;
   }
 
   /**
@@ -412,6 +452,18 @@ public final class Matcher {
    * @return the argument {@code sb}, for method chaining
    */
   public StringBuffer appendTail(StringBuffer sb) {
+    sb.append(substring(appendPos, inputLength));
+    return sb;
+  }
+
+  /**
+   * Appends to {@code sb} the substring of the input from the
+   * append position to the end of the input.
+   *
+   * @param sb the {@link StringBuilder} to append to
+   * @return the argument {@code sb}, for method chaining
+   */
+  public StringBuilder appendTail(StringBuilder sb) {
     sb.append(substring(appendPos, inputLength));
     return sb;
   }

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -261,10 +261,23 @@ public class MatcherTest {
   }
 
   @Test
-  public void testAppendTail() {
+  public void testAppendTail_StringBuffer() {
     Pattern p = Pattern.compile("cat");
     Matcher m = p.matcher("one cat two cats in the yard");
     StringBuffer sb = new StringBuffer();
+    while (m.find()) {
+      m.appendReplacement(sb, "dog");
+    }
+    m.appendTail(sb);
+    m.appendTail(sb);
+    assertEquals("one dog two dogs in the yards in the yard", sb.toString());
+  }
+
+  @Test
+  public void testAppendTail_StringBuilder() {
+    Pattern p = Pattern.compile("cat");
+    Matcher m = p.matcher("one cat two cats in the yard");
+    StringBuilder sb = new StringBuilder();
     while (m.find()) {
         m.appendReplacement(sb, "dog");
     }
@@ -274,7 +287,7 @@ public class MatcherTest {
   }
 
   @Test
-  public void testResetOnFindInt() {
+  public void testResetOnFindInt_StringBuffer() {
     StringBuffer buffer;
     Matcher matcher = Pattern.compile("a").matcher("zza");
 
@@ -294,7 +307,27 @@ public class MatcherTest {
   }
 
   @Test
-  public void testEmptyReplacementGroups() {
+  public void testResetOnFindInt_StringBuilder() {
+    StringBuilder buffer;
+    Matcher matcher = Pattern.compile("a").matcher("zza");
+
+    assertTrue(matcher.find());
+
+    buffer = new StringBuilder();
+    matcher.appendReplacement(buffer, "foo");
+    assertEquals("1st time",
+        "zzfoo", buffer.toString());
+
+    assertTrue(matcher.find(0));
+
+    buffer = new StringBuilder();
+    matcher.appendReplacement(buffer, "foo");
+    assertEquals("2nd time",
+        "zzfoo", buffer.toString());
+  }
+
+  @Test
+  public void testEmptyReplacementGroups_StringBuffer() {
     StringBuffer buffer = new StringBuffer();
     Matcher matcher = Pattern.compile("(a)(b$)?(b)?").matcher("abc");
     assertTrue(matcher.find());
@@ -318,6 +351,38 @@ public class MatcherTest {
     assertEquals("a-b", buffer.toString());
 
     buffer = new StringBuffer();
+    matcher = Pattern.compile("^(.)[^-]+(-.)?(.*)").matcher("Name");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1$2");
+    matcher.appendTail(buffer);
+    assertEquals("N", buffer.toString());
+  }
+
+  @Test
+  public void testEmptyReplacementGroups_StringBuilder() {
+    StringBuilder buffer = new StringBuilder();
+    Matcher matcher = Pattern.compile("(a)(b$)?(b)?").matcher("abc");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1-$2-$3");
+    assertEquals("a--b", buffer.toString());
+    matcher.appendTail(buffer);
+    assertEquals("a--bc", buffer.toString());
+
+    buffer = new StringBuilder();
+    matcher = Pattern.compile("(a)(b$)?(b)?").matcher("ab");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1-$2-$3");
+    matcher.appendTail(buffer);
+    assertEquals("a-b-", buffer.toString());
+
+    buffer = new StringBuilder();
+    matcher = Pattern.compile("(^b)?(b)?c").matcher("abc");
+    assertTrue(matcher.find());
+    matcher.appendReplacement(buffer, "$1-$2");
+    matcher.appendTail(buffer);
+    assertEquals("a-b", buffer.toString());
+
+    buffer = new StringBuilder();
     matcher = Pattern.compile("^(.)[^-]+(-.)?(.*)").matcher("Name");
     assertTrue(matcher.find());
     matcher.appendReplacement(buffer, "$1$2");


### PR DESCRIPTION
Add appendReplacement and appendTail methods that accept StringBuilders.
StringBuffer performs synchronization that is rarely necessary and has
performance overhead.

This change mirrors additions to java.util.regex.Matcher made in JDK 9:
https://bugs.openjdk.java.net/browse/JDK-8039124