### PR TITLE
Named group support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ different package name, it doesn't support the following parts of the
 interface:
 
 * the MatchResult class
-* Matcher.group(String)
 * Matcher.hasAnchoringBounds()
 * Matcher.hasTransparentBounds()
 * Matcher.hitEnd()

--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -2,6 +2,8 @@
 
 package com.google.re2j;
 
+import java.util.Map;
+
 /**
  * A stateful iterator that interprets a regex {@code Pattern} on a specific input. Its interface
  * mimics the JDK 1.4.2 {@code java.util.regex.Matcher}.
@@ -37,6 +39,8 @@ public final class Matcher {
   // The group indexes, in [start, end) pairs.  Zeroth pair is overall match.
   private final int[] groups;
 
+  private final Map<String, Integer> namedGroups;
+
   // The number of submatches (groups) in the pattern.
   private final int groupCount;
 
@@ -66,6 +70,7 @@ public final class Matcher {
     RE2 re2 = pattern.re2();
     groupCount = re2.numberOfCapturingGroups();
     groups = new int[2 + 2 * groupCount];
+    namedGroups = re2.namedGroups;
   }
 
   /** Creates a new {@code Matcher} with the given pattern and input. */
@@ -138,6 +143,21 @@ public final class Matcher {
   }
 
   /**
+   * Returns the start of the named group of the most recent match, or -1 if the group was not
+   * matched.
+   *
+   * @param group the group name
+   * @throws IllegalArgumentException if no group with that name exists
+   */
+  public int start(String group) {
+    Integer g = namedGroups.get(group);
+    if (g == null) {
+      throw new IllegalArgumentException("group '" + group + "' not found");
+    }
+    return start(g);
+  }
+
+  /**
    * Returns the end position of a subgroup of the most recent match.
    *
    * @param group the group index; 0 is the overall match
@@ -147,6 +167,21 @@ public final class Matcher {
   public int end(int group) {
     loadGroup(group);
     return groups[2 * group + 1];
+  }
+
+  /**
+   * Returns the end of the named group of the most recent match, or -1 if the group was not
+   * matched.
+   *
+   * @param group the group name
+   * @throws IllegalArgumentException if no group with that name exists
+   */
+  public int end(String group) {
+    Integer g = namedGroups.get(group);
+    if (g == null) {
+      throw new IllegalArgumentException("group '" + group + "' not found");
+    }
+    return end(g);
   }
 
   /**
@@ -172,6 +207,20 @@ public final class Matcher {
       return null;
     }
     return substring(start, end);
+  }
+
+  /**
+   * Returns the named group of the most recent match, or {@code null} if the group was not matched.
+   *
+   * @param group the group name
+   * @throws IllegalArgumentException if no group with that name exists
+   */
+  public String group(String group) {
+    Integer g = namedGroups.get(group);
+    if (g == null) {
+      throw new IllegalArgumentException("group '" + group + "' not found");
+    }
+    return group(g);
   }
 
   /**

--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -391,14 +391,8 @@ public final class Matcher {
    * @throws IndexOutOfBoundsException if replacement refers to an invalid group
    */
   public Matcher appendReplacement(StringBuffer sb, String replacement) {
-    int s = start();
-    int e = end();
-    if (appendPos < s) {
-      sb.append(substring(appendPos, s));
-    }
-    appendPos = e;
     StringBuilder result = new StringBuilder();
-    appendReplacementInternal(result, replacement);
+    appendReplacement(result, replacement);
     sb.append(result);
     return this;
   }

--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -467,6 +467,23 @@ public final class Matcher {
           last = i;
           i--;
           continue;
+        } else if (c == '{') {
+          if (last < i) {
+            sb.append(replacement.substring(last, i));
+          }
+          i++; // skip {
+          int j = i + 1;
+          while (j < replacement.length()
+              && replacement.charAt(j) != '}'
+              && replacement.charAt(j) != ' ') {
+            j++;
+          }
+          if (j == replacement.length() || replacement.charAt(j) != '}') {
+            throw new IllegalArgumentException("named capture group is missing trailing '}'");
+          }
+          String groupName = replacement.substring(i + 1, j);
+          sb.append(group(groupName));
+          last = j + 1;
         }
       }
     }

--- a/java/com/google/re2j/RE2.java
+++ b/java/com/google/re2j/RE2.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 
 /**
@@ -116,6 +117,7 @@ class RE2 {
   // Accesses must be serialized using |this| monitor.
   // @GuardedBy("this")
   private final Queue<Machine> machine = new ArrayDeque<Machine>();
+  public Map<String, Integer> namedGroups;
 
   // This is visible for testing.
   RE2(String expr) {
@@ -195,6 +197,7 @@ class RE2 {
     if (!re2.prefix.isEmpty()) {
       re2.prefixRune = re2.prefix.codePointAt(0);
     }
+    re2.namedGroups = re.namedGroups;
     return re2;
   }
 

--- a/java/com/google/re2j/Regexp.java
+++ b/java/com/google/re2j/Regexp.java
@@ -8,6 +8,7 @@
 package com.google.re2j;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * Regular expression abstract syntax tree. Produced by parser, used by compiler. NB, this
@@ -56,6 +57,7 @@ class Regexp {
   int min, max; // min, max for REPEAT
   int cap; // capturing index, for CAPTURE
   String name; // capturing name, for CAPTURE
+  Map<String, Integer> namedGroups; // map of group name -> capturing index
   // Do update copy ctor when adding new fields!
 
   Regexp(Op op) {
@@ -72,6 +74,7 @@ class Regexp {
     this.max = that.max;
     this.cap = that.cap;
     this.name = that.name;
+    this.namedGroups = that.namedGroups;
   }
 
   void reinit() {

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -431,4 +431,34 @@ public class MatcherTest {
     b.replace(b.indexOf("ban"), start + 3, "b");
     assertTrue(m.find(b.indexOf("ban")));
   }
+
+  @Test
+  public void testNamedGroups() {
+    Pattern p =
+        Pattern.compile(
+            "(?P<baz>f(?P<foo>b*a(?P<another>r+)){0,10})" + "(?P<bag>bag)?(?P<nomatch>zzz)?");
+    Matcher m = p.matcher("fbbarrrrrbag");
+    assertTrue(m.matches());
+    assertEquals("fbbarrrrr", m.group("baz"));
+    assertEquals("bbarrrrr", m.group("foo"));
+    assertEquals("rrrrr", m.group("another"));
+    assertEquals(0, m.start("baz"));
+    assertEquals(1, m.start("foo"));
+    assertEquals(4, m.start("another"));
+    assertEquals(9, m.end("baz"));
+    assertEquals(9, m.end("foo"));
+    assertEquals("bag", m.group("bag"));
+    assertEquals(9, m.start("bag"));
+    assertEquals(12, m.end("bag"));
+    assertEquals(null, m.group("nomatch"));
+    assertEquals(-1, m.start("nomatch"));
+    assertEquals(-1, m.end("nomatch"));
+
+    try {
+      m.group("nonexistent");
+      fail("Should have thrown IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      // Expected
+    }
+  }
 }

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -453,6 +453,7 @@ public class MatcherTest {
     assertEquals(null, m.group("nomatch"));
     assertEquals(-1, m.start("nomatch"));
     assertEquals(-1, m.end("nomatch"));
+    assertEquals("whatbbarrrrreverbag", appendReplacement(m, "what$2ever${bag}"));
 
     try {
       m.group("nonexistent");
@@ -460,5 +461,11 @@ public class MatcherTest {
     } catch (IllegalArgumentException expected) {
       // Expected
     }
+  }
+
+  private String appendReplacement(Matcher m, String replacement) {
+    StringBuilder b = new StringBuilder();
+    m.appendReplacement(b, replacement);
+    return b.toString();
   }
 }

--- a/javatests/com/google/re2j/ParserTest.java
+++ b/javatests/com/google/re2j/ParserTest.java
@@ -528,6 +528,8 @@ public class ParserTest {
     "(?i)[a-Z]",
     "a{100000}",
     "a{100000,}",
+    // Group names may not be repeated
+    "(?P<foo>bar)(?P<foo>baz)",
   };
 
   private static final String[] ONLY_PERL = {


### PR DESCRIPTION
This changes the parser to annotate the returned Regexp with information
about named capture groups. During compliation, this information is
passed along to the RE2 instance and thence to the Matcher.