### PR TITLE
Detect invalid unicode class specification

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -1539,6 +1539,10 @@ class Parser {
     if (c == 'P') {
       sign = -1;
     }
+    if (!t.more()) {
+      t.rewindTo(startPos);
+      throw new PatternSyntaxException(ERR_INVALID_CHAR_RANGE, t.rest());
+    }
     c = t.pop();
     String name;
     if (c != '{') {

--- a/javatests/com/google/re2j/RE2CompileTest.java
+++ b/javatests/com/google/re2j/RE2CompileTest.java
@@ -44,6 +44,8 @@ public class RE2CompileTest {
       {"a**", "invalid nested repetition operator: `**`"},
       {"a*+", "invalid nested repetition operator: `*+`"},
       {"\\x", "invalid escape sequence: `\\x`"},
+      {"\\p", "invalid character class range: `\\p`"},
+      {"\\p{", "invalid character class range: `\\p{`"}
     };
   }
 


### PR DESCRIPTION
Previously, the parser would unconditionally attempt to read the unicode
class spec after a \p or \P, even if the pattern is truncated and
invalid.

Fixes issue #72.