### PR TITLE
Allow parallel execution of tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ sourceSets {
   }
 }
 
+test {
+  // Allow parallel test execution.
+  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
 configurations.benchmarksCompile {
   resolutionStrategy.eachDependency { DependencyResolveDetails details ->
     if (details.requested.group == 'com.google.guava' && details.requested.name == 'guava') {


### PR DESCRIPTION
On my machine, this reduces a clean build and check from 29s to 19s.