### PR TITLE
Use a separate fake GWT module with the entry point.

### DIFF
--- a/javatests/com/google/re2j/GWTTest.java
+++ b/javatests/com/google/re2j/GWTTest.java
@@ -36,6 +36,10 @@ public class GWTTest {
     String projectRoot = System.getProperty("user.dir");
     addFiles(jar, "", new File(projectRoot, "java"));
     addFiles(jar, "", new File(projectRoot, "/target/classes"));
+    addFile(
+        jar,
+        "com/google/re2j",
+        new File(projectRoot, "/build/resources/test/com/google/re2j/RE2J-Fake.gwt.xml"));
     jar.finish();
     jar.close();
 
@@ -53,7 +57,7 @@ public class GWTTest {
                 Joiner.on(File.pathSeparatorChar)
                     .join(jarFile.getAbsolutePath(), System.getProperty("java.class.path")),
                 "com.google.gwt.dev.Compiler",
-                "com.google.re2j.RE2J")
+                "com.google.re2j.RE2J-Fake")
             .directory(gwtProjectDir.getRoot())
             .redirectErrorStream(true)
             .start();

--- a/testdata/com/google/re2j/RE2J-Fake.gwt.xml
+++ b/testdata/com/google/re2j/RE2J-Fake.gwt.xml
@@ -1,5 +1,7 @@
 <module rename-to="re2j">
     <inherits name="com.google.gwt.user.User" />
+    <!-- Entry point is necessary to get GWT to build anything at all. -->
+    <entry-point class="com.google.re2j.FakeGWTEntryPoint" />
     <source path=""/>
     <super-source path="super"/>
 </module>


### PR DESCRIPTION
This caused errors in some GWT applications, and GWTTest passes without it.