### PR TITLE
Include the RE2J.gwt.xml file in the release jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ sourceSets {
       srcDir 'java'
       exclude 'com/google/re2j/super/**'
     }
+    resources {
+      srcDir 'java'
+      include 'com/google/re2j/RE2J.gwt.xml'
+    }
   }
   test {
     java {


### PR DESCRIPTION
Tested by running `gradle jar` and verifying that RE2J.gwt.xml is included.