### PR TITLE
Release version 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you're using Maven, you can use the following snippet in your `pom.xml` to ge
 <dependency>
   <groupId>com.google.re2j</groupId>
   <artifactId>re2j</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java-library'
   id 'wrapper'
-  id 'com.jfrog.bintray' version '1.7.3'
+  id 'com.jfrog.bintray' version '1.8.1'
   id 'maven-publish'
   id 'com.github.sherter.google-java-format' version '0.3.2'
   id 'net.ltgt.errorprone' version '0.0.11'
@@ -15,7 +15,7 @@ plugins {
 cobertura.coverageFormats = ['html', 'xml']
 
 // The name of the release we're working on. See RELEASING.md for details.
-def versionName = '1.2'
+def versionName = '1.3'
 
 wrapper {
   gradleVersion '4.9'
@@ -116,8 +116,6 @@ task benchmarks(type: JavaExec) {
   main = 'com.google.re2j.Benchmarks'
 }
 
-def releaseVersion = '1.2'
-
 task sourceJar(type: Jar) {
     baseName 'sources'
 
@@ -164,7 +162,7 @@ publishing {
 
       groupId 'com.google.re2j'
       artifactId 're2j'
-      version releaseVersion
+      version versionName
 
       pom.withXml {
         appendMavenCentralMetadata(asNode())


### PR DESCRIPTION
Updated bintray plugin version to 1.8.1, release wouldn't succeed
without it.

Fixed an issue where we had two release name variables for some reason.