### PR TITLE
Fix link of latest release tag is old.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you're using Maven, you can use the following snippet in your `pom.xml` to ge
 
 You can use the same artifact details in any build system compatible with the Maven Central repositories (e.g. Gradle, Ivy).
 
-You can also download RE2/J the old-fashioned way: go to [the latest RE2/J release tag](https://github.com/google/re2j/releases/tag/re2j-1.1), download the RE2/J JAR and add it to your CLASSPATH.
+You can also download RE2/J the old-fashioned way: go to [the RE2/J release tag](https://github.com/google/re2j/releases), download the RE2/J JAR and add it to your CLASSPATH.
 
 # Discussion and contribution
 


### PR DESCRIPTION
Fix link of "latest release tag", because link is old version of re2j.

Because in github tag page, latest release is displayed in release page,
So It is good enogth that write link to release page, I think.