### PR TITLE
Drop Travis checks for Java 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: precise
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 
 # Works around an issue in Travis, see
 # https://github.com/travis-ci/travis-ci/issues/5227.


### PR DESCRIPTION
Gradle no longer works with Java 7 without workaround flags, and it's
probably time to move on from Java 7 anyway.