### PR TITLE
Fix handling of truncated two-digit hex escapes

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -1411,6 +1411,9 @@ class Parser {
 
         // Easy case: two hex digits.
         int x = Utils.unhex(c);
+        if (!t.more()) {
+          break;
+        }
         c = t.pop();
         int y = Utils.unhex(c);
         if (x < 0 || y < 0) {

--- a/javatests/com/google/re2j/ParserTest.java
+++ b/javatests/com/google/re2j/ParserTest.java
@@ -530,6 +530,8 @@ public class ParserTest {
     "a{100000,}",
     // Group names may not be repeated
     "(?P<foo>bar)(?P<foo>baz)",
+    "\\x", // https://github.com/google/re2j/issues/103
+    "\\xv", // https://github.com/google/re2j/issues/103
   };
 
   private static final String[] ONLY_PERL = {


### PR DESCRIPTION
Previously, the parser was unconditionally pop()ing two chars without
checking if the second was available.

Fixes https://github.com/google/re2j/issues/103.