### PR TITLE
fix factoring of common prefixes in alternations

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -487,7 +487,12 @@ class Parser {
       Regexp ifirst = null;
       if (i < lensub) {
         ifirst = leadingRegexp(array[s + i]);
-        if (first != null && first.equals(ifirst)) {
+        if (first != null
+            && first.equals(ifirst)
+            && (isCharClass(first)
+                || (first.op == Regexp.Op.REPEAT
+                    && first.min == first.max
+                    && isCharClass(first.subs[0])))) {
           continue;
         }
       }

--- a/javatests/com/google/re2j/ParserTest.java
+++ b/javatests/com/google/re2j/ParserTest.java
@@ -243,7 +243,10 @@ public class ParserTest {
       "abc|abd|aef|bcx|bcy",
       "alt{cat{lit{a}alt{cat{lit{b}cc{0x63-0x64}}str{ef}}}cat{str{bc}cc{0x78-0x79}}}"
     },
-    {"ax+y|ax+z|ay+w", "cat{lit{a}alt{cat{plus{lit{x}}cc{0x79-0x7a}}cat{plus{lit{y}}lit{w}}}}"},
+    {
+      "ax+y|ax+z|ay+w",
+      "cat{lit{a}alt{cat{plus{lit{x}}lit{y}}cat{plus{lit{x}}lit{z}}cat{plus{lit{y}}lit{w}}}}"
+    },
 
     // Bug fixes.
 
@@ -271,9 +274,10 @@ public class ParserTest {
     {"abc|x|abd", "alt{str{abc}lit{x}str{abd}}"},
     {"(?i)abc|ABD", "cat{strfold{AB}cc{0x43-0x44 0x63-0x64}}"},
     {"[ab]c|[ab]d", "cat{cc{0x61-0x62}cc{0x63-0x64}}"},
-    {"(?:xx|yy)c|(?:xx|yy)d", "cat{alt{str{xx}str{yy}}cc{0x63-0x64}}"},
+    {".c|.d", "cat{dot{}cc{0x63-0x64}}"},
     {"x{2}|x{2}[0-9]", "cat{rep{2,2 lit{x}}alt{emp{}cc{0x30-0x39}}}"},
     {"x{2}y|x{2}[0-9]y", "cat{rep{2,2 lit{x}}alt{lit{y}cat{cc{0x30-0x39}lit{y}}}}"},
+    {"a.*?c|a.*?b", "cat{lit{a}alt{cat{nstar{dot{}}lit{c}}cat{nstar{dot{}}lit{b}}}}"},
   };
 
   // TODO(adonovan): add some tests for:

--- a/javatests/com/google/re2j/PatternTest.java
+++ b/javatests/com/google/re2j/PatternTest.java
@@ -2,6 +2,7 @@
 
 package com.google.re2j;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -150,6 +151,20 @@ public class PatternTest {
     ApiTestUtils.testGroupCount("(.*)(\\(a\\)b)(.*)a", 3);
   }
 
+  // See https://github.com/google/re2j/issues/93.
+  @Test
+  public void testIssue93() {
+    Pattern p1 = Pattern.compile("(a.*?c)|a.*?b");
+    Pattern p2 = Pattern.compile("a.*?c|a.*?b");
+
+    Matcher m1 = p1.matcher("abc");
+    m1.find();
+    Matcher m2 = p2.matcher("abc");
+    m2.find();
+
+    assertThat(m2.group()).isEqualTo(m1.group());
+  }
+
   @Test
   public void testQuote() {
     ApiTestUtils.testMatchesRE2(Pattern.quote("ab+c"), 0, "ab+c", "abc");
@@ -188,9 +203,9 @@ public class PatternTest {
     Pattern pattern2 = Pattern.compile("abc");
     Pattern pattern3 = Pattern.compile("def");
     Pattern pattern4 = Pattern.compile("abc", Pattern.CASE_INSENSITIVE);
-    Truth.assertThat(pattern1).isEqualTo(pattern2);
-    Truth.assertThat(pattern1).isNotEqualTo(pattern3);
-    Truth.assertThat(pattern1.hashCode()).isEqualTo(pattern2.hashCode());
-    Truth.assertThat(pattern1).isNotEqualTo(pattern4);
+    assertThat(pattern1).isEqualTo(pattern2);
+    assertThat(pattern1).isNotEqualTo(pattern3);
+    assertThat(pattern1.hashCode()).isEqualTo(pattern2.hashCode());
+    assertThat(pattern1).isNotEqualTo(pattern4);
   }
 }


### PR DESCRIPTION
In the past, `a.*?c|a.*?b` was factored to `a.*?[bc]`. Thus, given
"abc" as its input string, the automaton would consume "ab" and
then stop (when unanchored) whereas it should consume all of "abc"
as per leftmost semantics.

This fix is ported from Go's regex impl,
https://go-review.googlesource.com/c/go/+/18357/.

Fixes https://github.com/google/re2j/issues/93.