### PR TITLE
Fix treatment of \Q\E*

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -922,7 +922,9 @@ class Parser {
                     }
                     t.skipString(lit);
                     t.skipString("\\E");
-                    push(literalRegexp(lit, flags));
+                    for (int j = 0; j < lit.length(); j++) {
+                      literal(lit.charAt(j));
+                    }
                     break bigswitch;
                   }
                 case 'z':

--- a/javatests/com/google/re2j/ParserTest.java
+++ b/javatests/com/google/re2j/ParserTest.java
@@ -213,6 +213,7 @@ public class ParserTest {
     // Test Perl quoted literals
     {"\\Q+|*?{[\\E", "str{+|*?{[}"},
     {"\\Q+\\E+", "plus{lit{+}}"},
+    {"\\Qab\\E+", "cat{lit{a}plus{lit{b}}}"},
     {"\\Q\\\\E", "lit{\\}"},
     {"\\Q\\\\\\E", "str{\\\\}"},
 


### PR DESCRIPTION
Ports the fix of https://github.com/golang/go/issues/11187 to RE2/J. The
contents of a \Q...\E sequence is now treated as a sequence of literal
chars, not a single literal string.

Fixes https://github.com/google/re2j/issues/92.