### PR TITLE
Fix zero-width assertions in capture group eval

### DIFF
--- a/java/com/google/re2j/Machine.java
+++ b/java/com/google/re2j/Machine.java
@@ -252,8 +252,9 @@ class Machine {
         }
         add(runq, prog.start, pos, matchcap, flag, null);
       }
-      flag = Utils.emptyOpContext(rune, rune1);
-      step(runq, nextq, pos, pos + width, rune, flag, anchor, pos == in.endPos());
+      int nextPos = pos + width;
+      flag = in.context(nextPos);
+      step(runq, nextq, pos, nextPos, rune, flag, anchor, pos == in.endPos());
       if (width == 0) { // EOF
         break;
       }

--- a/java/com/google/re2j/MachineInput.java
+++ b/java/com/google/re2j/MachineInput.java
@@ -206,8 +206,8 @@ abstract class MachineInput {
     @Override
     int context(int pos) {
       pos += start;
-      int r1 = pos > start && pos <= end ? Character.codePointBefore(str, pos) : -1;
-      int r2 = pos < end ? Character.codePointAt(str, pos) : -1;
+      int r1 = pos > 0 && pos <= str.length() ? Character.codePointBefore(str, pos) : -1;
+      int r2 = pos < str.length() ? Character.codePointAt(str, pos) : -1;
       return Utils.emptyOpContext(r1, r2);
     }
 


### PR DESCRIPTION
This change makes `RE2.match(CharSequence input, int start, int end,
...)` treat `input` as extending from `(0, input.size()]` for the
purpose of zero-width assertions. Previously, `input` was considered to
extend from `(start, end]`.

This is required when evaluating capturing groups. RE2/J re-matches the
capturing group within a previous successful match, e.g.

```
Matcher m = Pattern.compile("(he)llo").matcher("hello world");
m.find() -> true
m.group(0) -> "hello"
m.group(1) -> "he"
```

During the evaluation of the last statement, RE2/J re-evaluates the
pattern within group(0) (i.e. "hello"). Before this change, RE2/J would
consider the position after 'o' and before 'w' to be both end-of-text
and end-of-line. This would cause zero-width matchers (e.g. $) to
incorrectly match, generating erroneous group matches in some cases.

Fixes https://github.com/google/re2j/issues/96, see that issue for more
information.