### PR TITLE
move RE2/J to version 1.5, allows for Debian packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you're using Maven, you can use the following snippet in your `pom.xml` to ge
 <dependency>
   <groupId>com.google.re2j</groupId>
   <artifactId>re2j</artifactId>
-  <version>1.4</version>
+  <version>1.5</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
 cobertura.coverageFormats = ['html', 'xml']
 
 // The name of the release we're working on. See RELEASING.md for details.
-def versionName = '1.4'
+def versionName = '1.5'
 
 wrapper {
   gradleVersion '4.9'


### PR DESCRIPTION
See issue #112, this will allow Debian package maintainers to use a
clean version of re2j rather than a commit hash.