### PR TITLE
Avoid locking for put methods for RE2. Fixes #46

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ test {
 
 dependencies {
   testCompile 'junit:junit:4.12'
-  testCompile 'com.google.gwt:gwt-dev:2.8.2'
-  testCompile 'com.google.gwt:gwt-user:2.8.2'
+  testCompile 'com.google.gwt:gwt-dev:2.9.0'
+  testCompile 'com.google.gwt:gwt-user:2.9.0'
   testCompile 'com.google.truth:truth:0.36'
 
   // Cobertura requires slf4j at runtime

--- a/java/com/google/re2j/Machine.java
+++ b/java/com/google/re2j/Machine.java
@@ -99,6 +99,7 @@ class Machine {
   private int[] matchcap;
   private int ncap;
 
+  // Pointer to form a linked stack for the pool of Machines.
   Machine next;
 
   /**

--- a/java/com/google/re2j/Machine.java
+++ b/java/com/google/re2j/Machine.java
@@ -113,6 +113,19 @@ class Machine {
     this.matchcap = new int[prog.numCap < 2 ? 2 : prog.numCap];
   }
 
+  /** Copy constructor, but does not include {@code next} */
+  Machine(Machine copy) {
+    this.re2 = copy.re2;
+    this.prog = copy.prog;
+    this.q0 = copy.q0;
+    this.q1 = copy.q1;
+    this.pool = copy.pool;
+    this.poolSize = copy.poolSize;
+    this.matched = copy.matched;
+    this.matchcap = copy.matchcap;
+    this.ncap = copy.ncap;
+  }
+
   // init() reinitializes an existing Machine for re-use on a new input.
   void init(int ncap) {
     // length change need new arrays

--- a/java/com/google/re2j/Machine.java
+++ b/java/com/google/re2j/Machine.java
@@ -99,6 +99,8 @@ class Machine {
   private int[] matchcap;
   private int ncap;
 
+  Machine next;
+
   /**
    * Constructs a matching Machine for the specified {@code RE2}.
    */

--- a/java/com/google/re2j/Machine.java
+++ b/java/com/google/re2j/Machine.java
@@ -99,7 +99,9 @@ class Machine {
   private int[] matchcap;
   private int ncap;
 
-  // Pointer to form a linked stack for the pool of Machines.
+  // Make sure to include new fields in the copy constructor
+
+  // Pointer to form a linked stack for the pool of Machines. Not included in copy constructor.
   Machine next;
 
   /**
@@ -115,6 +117,7 @@ class Machine {
 
   /** Copy constructor, but does not include {@code next} */
   Machine(Machine copy) {
+    // Make sure to include any new fields here
     this.re2 = copy.re2;
     this.prog = copy.prog;
     this.q0 = copy.q0;

--- a/java/com/google/re2j/RE2.java
+++ b/java/com/google/re2j/RE2.java
@@ -237,11 +237,11 @@ class RE2 {
     do {
       head = pooled.get();
       if (!isNewNode && head != null) {
-        // If an element had a non-null next pointer and it was previously in the stack, another
-        // thread might be trying to pop it out right now, and if it sees the same node now in the
-        // stack the pop will succeed, but the new top of the stack will be the stale value of next.
-        // Allocate a new Machine so that the CAS will not succeed if this node has been popped and
-        // re-pushed.
+        // If an element had a null next pointer and it was previously in the stack, another thread
+        // might be trying to pop it out right now, and if it sees the same node now in the
+        // stack the pop will succeed, but the new top of the stack will be the stale (null) value
+        // of next. Allocate a new Machine so that the CAS will not succeed if this node has been
+        // popped and re-pushed.
         m = new Machine(m);
         isNewNode = true;
       }


### PR DESCRIPTION
The locking could be avoided entirely by allocating wrapper objects for the stack nodes, but I'm not sure if that's desirable. I've also provided another approach that is more complex but offers lock-freedom when the cache is empty.