### PR TITLE
Improve split

### DIFF
--- a/benchmarks/src/main/java/com/google/re2j/benchmark/BenchmarkSplit.java
+++ b/benchmarks/src/main/java/com/google/re2j/benchmark/BenchmarkSplit.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 The Go Authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+package com.google.re2j.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkSplit {
+  @Param({"JDK", "RE2J"})
+  private Implementations impl;
+
+  private Implementations.Pattern pattern;
+
+  private String input;
+
+  @Setup
+  public void setup() {
+    pattern = Implementations.Pattern.compile(impl, "a");
+
+    StringBuilder b = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      b.append("this should be a pretty big string containing a few delimiters to split on");
+    }
+
+    input = b.toString();
+  }
+
+  @Benchmark
+  public void benchmarkSplit(Blackhole bh) {
+    bh.consume(pattern.split(input));
+  }
+}

--- a/benchmarks/src/main/java/com/google/re2j/benchmark/Implementations.java
+++ b/benchmarks/src/main/java/com/google/re2j/benchmark/Implementations.java
@@ -82,6 +82,8 @@ public enum Implementations {
 
     public abstract Matcher matcher(byte[] bytes);
 
+    public abstract String[] split(String str);
+
     public static class JdkPattern extends Pattern {
 
       private final java.util.regex.Pattern pattern;
@@ -98,6 +100,11 @@ public enum Implementations {
       @Override
       public Matcher matcher(byte[] bytes) {
         return new Matcher.JdkMatcher(pattern.matcher(new String(bytes)));
+      }
+
+      @Override
+      public String[] split(String str) {
+        return pattern.split(str);
       }
     }
 
@@ -117,6 +124,11 @@ public enum Implementations {
       @Override
       public Matcher matcher(byte[] bytes) {
         return new Matcher.Re2Matcher(pattern.matcher(bytes));
+      }
+
+      @Override
+      public String[] split(String str) {
+        return pattern.split(str);
       }
     }
   }

--- a/javatests/com/google/re2j/PatternTest.java
+++ b/javatests/com/google/re2j/PatternTest.java
@@ -148,16 +148,20 @@ public class PatternTest {
     // http://docs.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html#split(java.lang.CharSequence, int)
 
     String s = "boo:and:foo";
-    String regexp1 = ":";
-    String regexp2 = "o";
 
-    ApiTestUtils.testSplit(regexp1, s, 2, new String[] {"boo", "and:foo"});
-    ApiTestUtils.testSplit(regexp1, s, 5, new String[] {"boo", "and", "foo"});
-    ApiTestUtils.testSplit(regexp1, s, -2, new String[] {"boo", "and", "foo"});
-    ApiTestUtils.testSplit(regexp2, s, 5, new String[] {"b", "", ":and:f", "", ""});
-    ApiTestUtils.testSplit(regexp2, s, -2, new String[] {"b", "", ":and:f", "", ""});
-    ApiTestUtils.testSplit(regexp2, s, 0, new String[] {"b", "", ":and:f"});
-    ApiTestUtils.testSplit(regexp2, s, new String[] {"b", "", ":and:f"});
+    ApiTestUtils.testSplit(":", s, 2, new String[] {"boo", "and:foo"});
+    ApiTestUtils.testSplit(":", s, 5, new String[] {"boo", "and", "foo"});
+    ApiTestUtils.testSplit(":", s, -2, new String[] {"boo", "and", "foo"});
+    ApiTestUtils.testSplit("o", s, 5, new String[] {"b", "", ":and:f", "", ""});
+    ApiTestUtils.testSplit("o", s, -2, new String[] {"b", "", ":and:f", "", ""});
+    ApiTestUtils.testSplit("o", s, 0, new String[] {"b", "", ":and:f"});
+    ApiTestUtils.testSplit("o", s, new String[] {"b", "", ":and:f"});
+
+    // From https://github.com/google/re2j/issues/131.
+    ApiTestUtils.testSplit("x*", "foo", new String[] {"f", "o", "o"});
+    ApiTestUtils.testSplit("x*", "foo", 1, new String[] {"foo"});
+    ApiTestUtils.testSplit("x*", "f", 2, new String[] {"f", ""});
+    ApiTestUtils.testSplit(":", ":a::b", new String[] {"", "a", "", "b"});
   }
 
   @Test


### PR DESCRIPTION
Omit leading empty matches from Pattern.split, improve performance
Fixes #131.

This change modifies Pattern.split to omit a leading empty match. This
behavior was specified in JDK8 and brings RE2/J split into line with
more recent JDK implementations.

Furthermore, the split function no longer needs determine the number of
matches before assembling the result. The upshot is that the number of
find() calls is halved in many cases. The benchmark in the previous
change shows a significant improvement.

```
Reference impl (JDK):
BenchmarkSplit.benchmarkSplit     JDK  avgt    5  14.217 ± 0.410  us/op

RE2J (before):
BenchmarkSplit.benchmarkSplit    RE2J  avgt    5  95.807 ± 6.737  us/op

RE2J (after):
BenchmarkSplit.benchmarkSplit    RE2J  avgt    5  49.092 ± 0.717  us/op
```