### PR TITLE
Fix quoting of codepoints requiring surrogate pairs.

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -922,8 +922,10 @@ class Parser {
                     }
                     t.skipString(lit);
                     t.skipString("\\E");
-                    for (int j = 0; j < lit.length(); j++) {
-                      literal(lit.charAt(j));
+                    for (int j = 0; j < lit.length(); ) {
+                      int codepoint = lit.codePointAt(j);
+                      literal(codepoint);
+                      j += Character.charCount(codepoint);
                     }
                     break bigswitch;
                   }

--- a/javatests/com/google/re2j/PatternTest.java
+++ b/javatests/com/google/re2j/PatternTest.java
@@ -83,6 +83,11 @@ public class PatternTest {
     ApiTestUtils.testMatches("ab+c", "abbbc", "cbbba");
     ApiTestUtils.testMatches("ab.*c", "abxyzc", "ab\nxyzc");
     ApiTestUtils.testMatches("^ab.*c$", "abc", "xyz\nabc\ndef");
+
+    // Test quoted codepoints that require a surrogate pair. See https://github.com/google/re2j/issues/123.
+    String source = new StringBuilder().appendCodePoint(110781).toString();
+    ApiTestUtils.testMatches(source, source, "blah");
+    ApiTestUtils.testMatches("\\Q" + source + "\\E", source, "blah");
   }
 
   @Test


### PR DESCRIPTION
Previously, the parser would match each individual character within a
\Q...\E section. Runes requiring a surrogate pair would be incorrectly
treated as two individual characters.

E.g.

String source = new StringBuilder().appendCodePoint(110781).toString();

Before this change:
Parser.parse(source, ...) matches \x{1b0bd}
Parser.parse("\\Q" + source + "\\E", ...) matches \x{d82c}\x{dcbd}

After this change:
Parser.parse(source, ...) matches \x{1b0bd}
Parser.parse("\\Q" + source + "\\E", ...) matches \x{1b0bd}

Fixes https://github.com/google/re2j/issues/123.