### PR TITLE
Revert "Replaces String.getBytes("UTF") with getBytes(StandardCharsets.UTF_8)"

### DIFF
--- a/java/com/google/re2j/RE2.java
+++ b/java/com/google/re2j/RE2.java
@@ -20,9 +20,8 @@
 
 package com.google.re2j;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.re2j.MatcherInput.Encoding;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -191,7 +190,11 @@ class RE2 {
     StringBuilder prefixBuilder = new StringBuilder();
     re2.prefixComplete = prog.prefix(prefixBuilder);
     re2.prefix = prefixBuilder.toString();
-    re2.prefixUTF8 = re2.prefix.getBytes(UTF_8);
+    try {
+      re2.prefixUTF8 = re2.prefix.getBytes("UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException("can't happen");
+    }
     if (!re2.prefix.isEmpty()) {
       re2.prefixRune = re2.prefix.codePointAt(0);
     }


### PR DESCRIPTION
Reverts google/re2j#145 to keep re2j Android API level 14 compatible.