### PR TITLE
Fix NullPointerException in Parser#factor

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -550,7 +550,9 @@ class Parser {
         for (int j = start + 1; j < i; j++) {
           Regexp subMax = array[s + max], subJ = array[s + j];
           if (subMax.op.ordinal() < subJ.op.ordinal()
-              || (subMax.op == subJ.op && subMax.runes.length < subJ.runes.length)) {
+              || (subMax.op == subJ.op
+                  && (subMax.runes != null ? subMax.runes.length : 0)
+                      < (subJ.runes != null ? subJ.runes.length : 0))) {
             max = j;
           }
         }
@@ -782,7 +784,7 @@ class Parser {
   }
 
   /**
-   * Parse regular expression pattern {@var pattern} with mode flags {@var flags}.
+   * Parse regular expression pattern {@code pattern} with mode flags {@code flags}.
    */
   static Regexp parse(String pattern, int flags) throws PatternSyntaxException {
     return new Parser(pattern, flags).parseInternal();

--- a/javatests/com/google/re2j/RE2CompileTest.java
+++ b/javatests/com/google/re2j/RE2CompileTest.java
@@ -36,6 +36,7 @@ public class RE2CompileTest {
       {"[abc]", null},
       {"[^1234]", null},
       {"[^\n]", null},
+      {"..|.#|..", null},
       {"\\!\\\\", null},
       {"abc]", null}, // Matches the closing bracket literally.
       {"a??", null},


### PR DESCRIPTION
The corresponding Go implementation relies on len(nilArray) being zero.

This issue was identified by the OSS-Fuzz integration effort described
in https://github.com/google/re2j/issues/135.