### PR TITLE
Bintray is gone, we now publish directly to Sonatype Nexus

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,45 +9,74 @@ Maven Central and to the RE2/J GitHub site.
 The following are one-time setup steps. You must have:
 
 * git
-* an account on OSSRH, see the [initial setup section](http://central.sonatype.org/pages/ossrh-guide.html#initial-setup) of the OSSRH guide
+* an account on OSSRH, see the [initial setup
+  section](http://central.sonatype.org/pages/ossrh-guide.html#initial-setup) of
+  the OSSRH guide
 * access to the `com.google.re2` OSSRH repository. For this, you should
   request access by [filing a JIRA ticket](https://issues.sonatype.org/secure/CreateIssue!default.jspa)
   with the OSSRH folks
-* an Open Source account on [JFrog Bintray](https://bintray.com/signup/oss)
-* access to the Bintray [RE2/J organization](https://bintray.com/re2j/). To get
-  this, follow the link and click 'Join'. Your request will be moderated by
-  somebody already in the organization.
-* an [API key](https://www.jfrog.com/confluence/display/RTF/Updating+Your+Profile#UpdatingYourProfile-APIKey) for Bintray
+* a GPG key (see below)
+
+## GPG key
+
+You must create a GPG key for signing the RE2/J artifact. The key must be
+published to one of the GPG keyservers, otherwise Sonatype will reject the
+RE2/J artifact.
+
+```
+$ gpg --gen-key
+
+... follow the prompts
+
+$ gpg --list-keys
+/home/sjr/.gnupg/pubring.kbx
+----------------------------
+pub   rsa3072 2022-06-30 [SC] [expires: 2024-06-29]
+      ABCDEF01234567890ABCDEF01234567890ABCDEF
+uid           [ultimate] Your Name <your@email.com>
+sub   rsa3072 2022-06-30 [E] [expires: 2024-06-29]
+
+# Now send the key to the keyservers
+
+$ gpg --keyserver keys.openpgp.org --send-keys 90ABCDEF
+gpg: sending key 1234567890ABCDEF to hkp://keys.openpgp.org
+```
 
 # Making the release
 
 In a shell, change into the RE2/J source code root directory (the one
 containing `build.gradle`). Then:
 
-* edit `build.gradle` and set `versionName` to the name of the next release
-  (e.g. "1.3").
+* edit `build.gradle` and set `version` to the name of the next release
+  (e.g. "1.8").
 * change the download instructions in `README.md` to reflect the new version
   number
 * `git commit` the version name change
-* `git tag re2j-<versionName>`, e.g. `git tag re2j-1.3`
+* `git tag re2j-<versionName>`, e.g. `git tag re2j-1.8`
 * `git push --tags`
 
 Now you're ready to build and push the release.
 
 ```
-BINTRAY_USER=<your bintray username> BINTRAY_KEY=<your bintray API key> ./gradlew bintrayUpload
+./gradlew -Psonatype.username='sonatypeUsername' -Psonatype.password='sonatypeApiKey' \
+        clean bintrayUpload
 ```
 
-Once successful, the new version needs to be published. Log into Bintray, find
-the new version you have uploaded, then click 'Publish'. People may now use
-JCenter to get RE2/J.
+Once successful, the new version needs to be published:
 
-Some people still use Maven Central, so we push the artifact there as well.
-Click on "Maven Central", enter your OSSRH username and password, ensure the
-"Close and release" checkbox is selected and click "Sync". RE2/J will be synced
-to Maven Central after some time (usually around 10 minutes).
+1. Log into the [Sonatype Nexus frontend](https://oss.sonatype.org/)
+2. Click on "Staging Repositories" on the left
+3. Select the latest staging repository, click "Close"
+4. If all of the repository checks pass, the repository will be closed. You can
+   now click "Release". This will send the artifact out to Maven Central, ready
+   for people to use.
+
+As a convenience to our users, you should also publish the sources, javadoc and
+artifact JARs as GitHub releases.
+
+After this is all done, make an announcement on `re2j-discuss@googlegroups.com`.
 
 # Problems
 
 If you encounter issues, please reach out to the mailing list at
-re2j-discuss@googlegroups.com.
+`re2j-discuss@googlegroups.com`.

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@
 plugins {
   id 'java-library'
   id 'wrapper'
-  id 'com.jfrog.bintray' version '1.8.1'
   id 'maven-publish'
+  id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
   id 'com.github.sherter.google-java-format' version '0.3.2'
   id 'net.ltgt.errorprone' version '2.0.2'
   id 'idea'
+  id 'signing'
 
   // code coverage support
   id 'net.saliman.cobertura' version '2.5.4'
@@ -22,7 +23,8 @@ plugins {
 cobertura.coverageFormats = ['html', 'xml']
 
 // The name of the release we're working on. See RELEASING.md for details.
-def versionName = '1.6'
+group = "com.google.re2j"
+version = "1.7"
 
 wrapper {
   gradleVersion '5.2'
@@ -137,7 +139,7 @@ publishing {
 
       groupId 'com.google.re2j'
       artifactId 're2j'
-      version versionName
+      version project.version
 
       pom.withXml {
         appendMavenCentralMetadata(asNode())
@@ -146,26 +148,19 @@ publishing {
   }
 }
 
-bintray {
-  user = System.getenv('BINTRAY_USER')
-  key = System.getenv('BINTRAY_KEY')
+signing {
+  useGpgCmd()
 
-  pkg {
-    repo = 'maven'
-    name = 're2j'
-    userOrg = 're2j'
-    licenses = ['Go']
-    vcsUrl = 'https://github.com/google/re2j.git'
+  sign publishing.publications.mavenJava
+}
 
-    version {
-      name = versionName
-      desc = "RE2/J ${versionName}"
-      released = new Date()
-      vcsTag = "re2j-${versionName}"
+nexusPublishing {
+  repositories {
+    sonatype {
+      username = findProperty('sonatype.username')
+      password = findProperty('sonatype.password')
     }
   }
-
-  publications = ['mavenJava']
 }
 
 // If Java formatter checks fail, tell the user how to fix them.


### PR DESCRIPTION
This change allows RE2J to be released again. I updated the release
instructions, the test of whether they are accurate will be when I do
this process again in a few months!