### PR TITLE
Reduce the incidence of infinite loops while case folding

### DIFF
--- a/java/com/google/re2j/Inst.java
+++ b/java/com/google/re2j/Inst.java
@@ -51,8 +51,12 @@ final class Inst {
     if (runes.length == 1) {
       int r0 = runes[0];
 
+      // If this pattern is case-insensitive, apply Unicode case folding to compare the two runes.
+      // Note that this may result in a case-folding loop when executed on a JVM newer than the version used
+      // to generate Unicode data for re2j, so attempt to reduce the chance of that occurring
+      // by performing case folding on |r0| from the pattern rather than |r| from the input.
       if ((arg & RE2.FOLD_CASE) != 0) {
-        return Unicode.equalsIgnoreCase(r, r0);
+        return Unicode.equalsIgnoreCase(r0, r);
       }
       return r == r0;
     }

--- a/java/com/google/re2j/Unicode.java
+++ b/java/com/google/re2j/Unicode.java
@@ -125,6 +125,8 @@ class Unicode {
   // equalsIgnoreCase performs case-insensitive equality comparison
   // on the given runes |r1| and |r2|, with special consideration
   // for the likely scenario where both runes are ASCII characters.
+  // If non-ASCII, Unicode case folding will be performed on |r1|
+  // to compare it to |r2|.
   // -1 is interpreted as the end-of-file mark.
   static boolean equalsIgnoreCase(int r1, int r2) {
     // Runes already match, or one of them is EOF


### PR DESCRIPTION
dc7d6e5d41225dc0825ea6fe4c6055ff854abe13 unfortunately increases the
incidence of infinite loops during case folding if re2j is running on a
JVM newer than the version used to generate the bundled
UnicodeTables.java and the input contains a rune that would require
special case folding rules to form a closed fold loop. \u1C80 (Cyrillic
Small Letter Rounded Ve) is an example of such a rune.

Workaround the issue by inverting the order of parameters passed to
equalsIgnoreCase() so that the rune from the pattern being matched,
rather than the input content, undergoes case folding instead. This does
not fully eliminate the possibility of an infinite loop in this
scenario, since the pattern may well contain one of the problematic
runes, but it effectively restores the situation as it was pre
dc7d6e5d41225dc0825ea6fe4c6055ff854abe13, since the previous logic also
performed case folding on the rune from the pattern and not on the
content.
