### PR TITLE
Add support for `(?<name>expr)`.

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -1053,21 +1053,22 @@ class Parser {
     // support all three as well.  EcmaScript 4 uses only the Python form.
     //
     // In both the open source world (via Code Search) and the
-    // Google source tree, (?P<expr>name) is the dominant form,
-    // so that's the one we implement.  One is enough.
+    // Google source tree, (?P<name>expr) and (?<name>expr) are the
+    // dominant forms of named captures and both are supported.
     String s = t.rest();
-    if (s.startsWith("(?P<")) {
+    if (s.startsWith("(?P<") || s.startsWith("(?<")) {
       // Pull out name.
-      int end = s.indexOf('>');
+      int begin = s.charAt(2) == 'P' ? 4 : 3;
+      int end = s.indexOf('>', begin);
       if (end < 0) {
         throw new PatternSyntaxException(ERR_INVALID_NAMED_CAPTURE, s);
       }
-      String name = s.substring(4, end); // "name"
+      String name = s.substring(begin, end); // "name"
       t.skipString(name);
-      t.skip(5); // "(?P<>"
+      t.skip(begin + 1); // "(?P<>" or "(?<>"
       if (!isValidCaptureName(name)) {
         throw new PatternSyntaxException(
-            ERR_INVALID_NAMED_CAPTURE, s.substring(0, end)); // "(?P<name>"
+            ERR_INVALID_NAMED_CAPTURE, s.substring(0, end + 1)); // "(?P<name>" or "(?<name>"
       }
       // Like ordinary capture, but named.
       Regexp re = op(Regexp.Op.LEFT_PAREN);

--- a/javatests/com/google/re2j/ParserTest.java
+++ b/javatests/com/google/re2j/ParserTest.java
@@ -232,6 +232,7 @@ public class ParserTest {
 
     // Test named captures
     {"(?P<name>a)", "cap{name:lit{a}}"},
+    {"(?<name>a)", "cap{name:lit{a}}"},
 
     // Case-folded literals
     {"[Aa]", "litfold{A}"},
@@ -530,12 +531,20 @@ public class ParserTest {
     "(?P<name",
     "(?P<x y>a)",
     "(?P<>a)",
+    "(?<name>a",
+    "(?<name>",
+    "(?<name",
+    "(?<x y>a)",
+    "(?<>a)",
     "[a-Z]",
     "(?i)[a-Z]",
     "a{100000}",
     "a{100000,}",
     // Group names may not be repeated
     "(?P<foo>bar)(?P<foo>baz)",
+    "(?P<foo>bar)(?<foo>baz)",
+    "(?<foo>bar)(?P<foo>baz)",
+    "(?<foo>bar)(?<foo>baz)",
     "\\x", // https://github.com/google/re2j/issues/103
     "\\xv", // https://github.com/google/re2j/issues/103
   };
@@ -550,6 +559,7 @@ public class ParserTest {
     "\\Q\\\\\\\\\\E",
     "(?:a)",
     "(?P<name>a)",
+    "(?<name>a)",
   };
 
   private static final String[] ONLY_POSIX = {


### PR DESCRIPTION
This follows https://github.com/google/re2/commit/6148386 (and https://github.com/golang/go/commit/ee61186) to some extent.