### PR TITLE
Resolve groups when performing match operations

### DIFF
--- a/benchmarks/src/main/java/com/google/re2j/benchmark/BenchmarkSubMultiMatch.java
+++ b/benchmarks/src/main/java/com/google/re2j/benchmark/BenchmarkSubMultiMatch.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 The Go Authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+package com.google.re2j.benchmark;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkSubMultiMatch {
+
+  @Param({"JDK", "RE2J"})
+  private Implementations impl;
+
+  @Param({"true", "false"})
+  private boolean binary;
+
+  @Param({"true", "false"})
+  private boolean successMatch;
+
+  @Param({"true", "false"})
+  private boolean resolveGroups;
+
+  byte[] bytes = BenchmarkUtils.readResourceFile("google-maps-contact-info.html");
+  private String html = new String(bytes, StandardCharsets.UTF_8);
+
+  private String sucessPatternUrlString =
+      "(https?:\\/\\/(www\\.)?([-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,4})\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*))";
+  private String failurePatternUrlString =
+      "(https?:\\/\\/(www\\.)?([-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{1})\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*))";
+  private Implementations.Pattern successPattern;
+  private Implementations.Pattern failurePattern;
+  private Implementations.Pattern successPatternResolveGroups;
+  private Implementations.Pattern failurePatternResolveGroups;
+
+  @Setup
+  public void setup() {
+    successPattern = Implementations.Pattern.compile(impl, sucessPatternUrlString);
+    successPatternResolveGroups =
+        Implementations.Pattern.compile(
+            impl, sucessPatternUrlString, Implementations.Pattern.FLAG_RESOLVE_GROUPS_MATCH);
+    failurePattern = Implementations.Pattern.compile(impl, failurePatternUrlString);
+    failurePatternResolveGroups =
+        Implementations.Pattern.compile(
+            impl, failurePatternUrlString, Implementations.Pattern.FLAG_RESOLVE_GROUPS_MATCH);
+  }
+
+  @Benchmark
+  public void findDomains(Blackhole bh) {
+    Implementations.Pattern pattern =
+        successMatch
+            ? (resolveGroups ? successPatternResolveGroups : successPattern)
+            : (resolveGroups ? failurePatternResolveGroups : failurePattern);
+    Implementations.Matcher matcher = binary ? pattern.matcher(bytes) : pattern.matcher(html);
+    int count = 0;
+    while (matcher.find()) {
+      bh.consume(matcher.group(3));
+      count++;
+    }
+    int expectedMatchers = successMatch ? 178 : 0;
+    if (count != expectedMatchers) {
+      throw new AssertionError("Expected " + expectedMatchers + " matches.");
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/google/re2j/benchmark/Implementations.java
+++ b/benchmarks/src/main/java/com/google/re2j/benchmark/Implementations.java
@@ -18,6 +18,8 @@ public enum Implementations {
 
     public abstract String group();
 
+    public abstract String group(int group);
+
     public static class Re2Matcher extends Matcher {
       private final com.google.re2j.Matcher matcher;
 
@@ -38,6 +40,11 @@ public enum Implementations {
       @Override
       public String group() {
         return matcher.group();
+      }
+
+      @Override
+      public String group(int group) {
+        return matcher.group(group);
       }
     }
 
@@ -62,6 +69,11 @@ public enum Implementations {
       public String group() {
         return matcher.group();
       }
+
+      @Override
+      public String group(int group) {
+        return matcher.group(group);
+      }
     }
   }
 
@@ -70,6 +82,9 @@ public enum Implementations {
     // FLAG_CASE_INSENSITIVE is an implementation-agnostic bitmask flag
     // indicating that a pattern should be case-insensitive.
     public static final int FLAG_CASE_INSENSITIVE = 1;
+
+    // FLAG_RESOLVE_GROUPS_MATCH enable RE2J to resolve all groups during match operation.
+    public static final int FLAG_RESOLVE_GROUPS_MATCH = 32;
 
     public static Pattern compile(Implementations impl, String pattern) {
       return compile(impl, pattern, 0);
@@ -135,6 +150,9 @@ public enum Implementations {
         int re2PatternFlags = 0;
         if ((flags & FLAG_CASE_INSENSITIVE) > 0) {
           re2PatternFlags |= com.google.re2j.Pattern.CASE_INSENSITIVE;
+        }
+        if ((flags & FLAG_RESOLVE_GROUPS_MATCH) > 0) {
+          re2PatternFlags |= com.google.re2j.Pattern.RESOLVE_GROUPS_MATCH;
         }
         this.pattern = com.google.re2j.Pattern.compile(pattern, re2PatternFlags);
       }

--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -349,12 +349,21 @@ public final class Matcher {
   private boolean genMatch(int startByte, int anchor) {
     // TODO(rsc): Is matches/lookingAt supposed to reset the append or input positions?
     // From the JDK docs, looks like no.
-    boolean ok = pattern.re2().match(matcherInput, startByte, inputLength, anchor, groups, 1);
+    boolean ok =
+        pattern
+            .re2()
+            .match(
+                matcherInput,
+                startByte,
+                inputLength,
+                anchor,
+                groups,
+                pattern.re2().resolveAllGroups ? 1 + groupCount : 1);
     if (!ok) {
       return false;
     }
     hasMatch = true;
-    hasGroups = false;
+    hasGroups = pattern.re2().resolveAllGroups;
     anchorFlag = anchor;
 
     return true;

--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -50,6 +50,11 @@ public final class Pattern implements Serializable {
    */
   public static final int LONGEST_MATCH = 16;
 
+  /**
+   * Flag: match and find operations resolves all groups.
+   */
+  public static final int RESOLVE_GROUPS_MATCH = 32;
+
   // The pattern string at construction time.
   private final String pattern;
 
@@ -130,11 +135,17 @@ public final class Pattern implements Serializable {
     if ((flags & MULTILINE) != 0) {
       flregex = "(?m)" + flregex;
     }
-    if ((flags & ~(MULTILINE | DOTALL | CASE_INSENSITIVE | DISABLE_UNICODE_GROUPS | LONGEST_MATCH))
+    if ((flags
+            & ~(MULTILINE
+                | DOTALL
+                | CASE_INSENSITIVE
+                | DISABLE_UNICODE_GROUPS
+                | LONGEST_MATCH
+                | RESOLVE_GROUPS_MATCH))
         != 0) {
       throw new IllegalArgumentException(
           "Flags should only be a combination "
-              + "of MULTILINE, DOTALL, CASE_INSENSITIVE, DISABLE_UNICODE_GROUPS, LONGEST_MATCH");
+              + "of MULTILINE, DOTALL, CASE_INSENSITIVE, DISABLE_UNICODE_GROUPS, LONGEST_MATCH, RESOLVE_GROUPS_MATCH");
     }
     return compile(flregex, regex, flags);
   }
@@ -148,7 +159,13 @@ public final class Pattern implements Serializable {
       re2Flags &= ~RE2.UNICODE_GROUPS;
     }
     return new Pattern(
-        regex, flags, RE2.compileImpl(flregex, re2Flags, (flags & LONGEST_MATCH) != 0));
+        regex,
+        flags,
+        RE2.compileImpl(
+            flregex,
+            re2Flags,
+            ((flags & LONGEST_MATCH) != 0),
+            (flags & RESOLVE_GROUPS_MATCH) != 0));
   }
 
   /**

--- a/javatests/com/google/re2j/ExecTest.java
+++ b/javatests/com/google/re2j/ExecTest.java
@@ -567,7 +567,7 @@ public class ExecTest {
 
         RE2 re = null;
         try {
-          re = RE2.compileImpl(pattern, flags, true);
+          re = RE2.compileImpl(pattern, flags, true, false);
         } catch (PatternSyntaxException e) {
           if (shouldCompileMatch[0]) {
             System.err.format("%s:%d: %s did not compile\n", file, lineno, pattern);

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -428,6 +428,27 @@ public class MatcherTest {
   }
 
   @Test
+  public void testDocumentedExampleWithResolveGroups() {
+    Pattern p = Pattern.compile("b(an)*(.)", Pattern.RESOLVE_GROUPS_MATCH);
+    Matcher m = p.matcher("by, band, banana");
+    assertTrue(m.lookingAt());
+    m.reset();
+    assertTrue(m.find());
+    assertEquals("by", m.group(0));
+    assertNull(m.group(1));
+    assertEquals("y", m.group(2));
+    assertTrue(m.find());
+    assertEquals("band", m.group(0));
+    assertEquals("an", m.group(1));
+    assertEquals("d", m.group(2));
+    assertTrue(m.find());
+    assertEquals("banana", m.group(0));
+    assertEquals("an", m.group(1));
+    assertEquals("a", m.group(2));
+    assertFalse(m.find());
+  }
+
+  @Test
   public void testMutableCharSequence() {
     Pattern p = Pattern.compile("b(an)*(.)");
     StringBuilder b = new StringBuilder("by, band, banana");
@@ -443,6 +464,38 @@ public class MatcherTest {
     Pattern p =
         Pattern.compile(
             "(?P<baz>f(?P<foo>b*a(?P<another>r+)){0,10})" + "(?P<bag>bag)?(?P<nomatch>zzz)?");
+    Matcher m = p.matcher("fbbarrrrrbag");
+    assertTrue(m.matches());
+    assertEquals("fbbarrrrr", m.group("baz"));
+    assertEquals("bbarrrrr", m.group("foo"));
+    assertEquals("rrrrr", m.group("another"));
+    assertEquals(0, m.start("baz"));
+    assertEquals(1, m.start("foo"));
+    assertEquals(4, m.start("another"));
+    assertEquals(9, m.end("baz"));
+    assertEquals(9, m.end("foo"));
+    assertEquals("bag", m.group("bag"));
+    assertEquals(9, m.start("bag"));
+    assertEquals(12, m.end("bag"));
+    assertNull(m.group("nomatch"));
+    assertEquals(-1, m.start("nomatch"));
+    assertEquals(-1, m.end("nomatch"));
+    assertEquals("whatbbarrrrreverbag", appendReplacement(m, "what$2ever${bag}"));
+
+    try {
+      m.group("nonexistent");
+      fail("Should have thrown IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testNamedGroupsWithResolveGroups() {
+    Pattern p =
+        Pattern.compile(
+            "(?P<baz>f(?P<foo>b*a(?P<another>r+)){0,10})" + "(?P<bag>bag)?(?P<nomatch>zzz)?",
+            Pattern.RESOLVE_GROUPS_MATCH);
     Matcher m = p.matcher("fbbarrrrrbag");
     assertTrue(m.matches());
     assertEquals("fbbarrrrr", m.group("baz"));


### PR DESCRIPTION
By default, RE2J does not resolve all the groups when performing a match operation, rather it only resolves groups when `Matcher.group(*)` is called. This results in input being processed twice. Once during [find()](https://github.com/google/re2j/blob/master/java/com/google/re2j/Matcher.java#L352) and then again during [group(*)](https://github.com/google/re2j/blob/master/java/com/google/re2j/Matcher.java#L285). This increase the latency when `Matcher.find()` and `Matcher.group(*)` are called in succession. 

This Pull Request attempts to reduce the latency by half by resolving the groups when `Matcher.find()` is called, such that groups can be served from cache when `Matcher.group(*)` is called. 

We can clearly see from the following benchmark tests that when `resolveGroups == true` (When the groups are resolved during `find()`) and when `successMatch==ture` (When the patterns are matched) for binary data we are seeing 0.609 ms/op vs 1.147 ms/op, providing 47% latency gain. Similarly, when the `successMatch==false` (When there are no matching patterns) we are only seeing 4% regression (0.332 ms/op vs 0.319 ms/op). When string is used as the input, resolving groups during `find()` seems to outperform in all cases. 

```
Benchmark                           (binary)  (impl)  (resolveGroups)  (successMatch)  Mode  Cnt  Score   Error  Units
BenchmarkSubMultiMatch.findDomains      true     JDK             true            true  avgt    5  1.636 ± 0.095  ms/op
BenchmarkSubMultiMatch.findDomains      true     JDK             true           false  avgt    5  1.338 ± 0.036  ms/op
BenchmarkSubMultiMatch.findDomains      true     JDK            false            true  avgt    5  1.539 ± 0.052  ms/op
BenchmarkSubMultiMatch.findDomains      true     JDK            false           false  avgt    5  1.336 ± 0.039  ms/op
BenchmarkSubMultiMatch.findDomains      true    RE2J             true            true  avgt    5  0.609 ± 0.023  ms/op
BenchmarkSubMultiMatch.findDomains      true    RE2J             true           false  avgt    5  0.332 ± 0.008  ms/op
BenchmarkSubMultiMatch.findDomains      true    RE2J            false            true  avgt    5  1.147 ± 0.071  ms/op
BenchmarkSubMultiMatch.findDomains      true    RE2J            false           false  avgt    5  0.319 ± 0.007  ms/op
BenchmarkSubMultiMatch.findDomains     false     JDK             true            true  avgt    5  1.430 ± 0.311  ms/op
BenchmarkSubMultiMatch.findDomains     false     JDK             true           false  avgt    5  1.192 ± 0.031  ms/op
BenchmarkSubMultiMatch.findDomains     false     JDK            false            true  avgt    5  1.339 ± 0.064  ms/op
BenchmarkSubMultiMatch.findDomains     false     JDK            false           false  avgt    5  1.196 ± 0.009  ms/op
BenchmarkSubMultiMatch.findDomains     false    RE2J             true            true  avgt    5  0.610 ± 0.022  ms/op
BenchmarkSubMultiMatch.findDomains     false    RE2J             true           false  avgt    5  0.329 ± 0.004  ms/op
BenchmarkSubMultiMatch.findDomains     false    RE2J            false            true  avgt    5  1.100 ± 0.014  ms/op
BenchmarkSubMultiMatch.findDomains     false    RE2J            false           false  avgt    5  0.337 ± 0.039  ms/op
```

As there are use cases only `Matcher.find()` being called, and in such cases resolving groups can be an overkill, therefore I have enabled this optimization via a flag so we can tap into this optimization only when it's needed. 

Please provide your feedback on the pull request. I'm happy to make necessary changes to get this optimization merged. 