### PR TITLE
Add `Pattern.programSize()` and `Matcher.programSize()`

### DIFF
--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -50,6 +50,9 @@ public final class Matcher {
   // The number of submatches (groups) in the pattern.
   private final int groupCount;
 
+  // The number of instructions in the pattern.
+  private final int numberOfInstructions;
+
   private MatcherInput matcherInput;
 
   // The input length in UTF16 codes.
@@ -77,6 +80,7 @@ public final class Matcher {
     groupCount = re2.numberOfCapturingGroups();
     groups = new int[2 + 2 * groupCount];
     namedGroups = re2.namedGroups;
+    numberOfInstructions = re2.numberOfInstructions();
   }
 
   /** Creates a new {@code Matcher} with the given pattern and input. */
@@ -207,6 +211,21 @@ public final class Matcher {
       throw new IllegalArgumentException("group '" + group + "' not found");
     }
     return end(g);
+  }
+
+
+  /**
+   * Returns the program size of this pattern.
+   *
+   * <p>
+   * Similar to the C++ implementation, the program size is a very approximate measure of a regexp's
+   * "cost". Larger numbers are more expensive than smaller numbers.
+   * </p>
+   *
+   * @return the program size of this pattern
+   */
+  public int programSize() {
+    return numberOfInstructions;
   }
 
   /**

--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -213,7 +213,6 @@ public final class Matcher {
     return end(g);
   }
 
-
   /**
    * Returns the program size of this pattern.
    *

--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -301,6 +301,20 @@ public final class Pattern implements Serializable {
   }
 
   /**
+   * Returns the program size of this pattern.
+   *
+   * <p>
+   * Similar to the C++ implementation, the program size is a very approximate measure of a regexp's
+   * "cost". Larger numbers are more expensive than smaller numbers.
+   * </p>
+   *
+   * @return the program size of this pattern
+   */
+  public int programSize() {
+    return re2.numberOfInstructions();
+  }
+
+  /**
    * Returns the number of capturing groups in this matcher's pattern. Group zero denotes the entire
    * pattern and is excluded from this count.
    *

--- a/java/com/google/re2j/RE2.java
+++ b/java/com/google/re2j/RE2.java
@@ -209,6 +209,13 @@ class RE2 {
     return numSubexp;
   }
 
+  /**
+   * Returns the number of instructions in this compiled regular expression program.
+   */
+  int numberOfInstructions() {
+    return prog.numInst();
+  }
+
   // get() returns a machine to use for matching |this|.  It uses |this|'s
   // machine cache if possible, to avoid unnecessary allocation.
   Machine get() {

--- a/javatests/com/google/re2j/ApiTestUtils.java
+++ b/javatests/com/google/re2j/ApiTestUtils.java
@@ -159,6 +159,24 @@ public class ApiTestUtils {
     assertEquals(count, mj.groupCount());
   }
 
+  // Tests that both RE2 Patterns and Matchers give the same groupCount.
+  public static void testProgramSize(String pattern, int expectedSize) {
+    Pattern p = Pattern.compile(pattern);
+
+    String input = "foo";
+    byte[] inputBytes = getUtf8Bytes(input);
+    Matcher m1 = p.matcher(input);
+    Matcher m2 = p.matcher(inputBytes);
+
+    Truth.assertWithMessage("Pattern(\"%s\") program size", p)
+        .that(p.programSize()).isEqualTo(expectedSize);
+    Truth.assertWithMessage("Matcher(\"%s\", \"%s\") program size", m1.pattern(), input)
+        .that(m1.programSize()).isEqualTo(expectedSize);
+    Truth.assertWithMessage("Matcher(\"%s\", %s) program size", m2.pattern(),
+            Arrays.toString(inputBytes))
+        .that(m2.programSize()).isEqualTo(expectedSize);
+  }
+
   public static void testGroup(String text, String regexp, String[] output) {
     // RE2
     Pattern p = Pattern.compile(regexp);

--- a/javatests/com/google/re2j/ApiTestUtils.java
+++ b/javatests/com/google/re2j/ApiTestUtils.java
@@ -169,12 +169,15 @@ public class ApiTestUtils {
     Matcher m2 = p.matcher(inputBytes);
 
     Truth.assertWithMessage("Pattern(\"%s\") program size", p)
-        .that(p.programSize()).isEqualTo(expectedSize);
+        .that(p.programSize())
+        .isEqualTo(expectedSize);
     Truth.assertWithMessage("Matcher(\"%s\", \"%s\") program size", m1.pattern(), input)
-        .that(m1.programSize()).isEqualTo(expectedSize);
-    Truth.assertWithMessage("Matcher(\"%s\", %s) program size", m2.pattern(),
-            Arrays.toString(inputBytes))
-        .that(m2.programSize()).isEqualTo(expectedSize);
+        .that(m1.programSize())
+        .isEqualTo(expectedSize);
+    Truth.assertWithMessage(
+            "Matcher(\"%s\", %s) program size", m2.pattern(), Arrays.toString(inputBytes))
+        .that(m2.programSize())
+        .isEqualTo(expectedSize);
   }
 
   public static void testGroup(String text, String regexp, String[] output) {

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -102,9 +102,11 @@ public class MatcherTest {
     int programSize = pattern.programSize();
     Truth.assertWithMessage("Pattern program size").that(programSize).isGreaterThan(1);
     Truth.assertWithMessage("Positive matcher program size")
-        .that(pattern.matcher("good").programSize()).isEqualTo(programSize);
+        .that(pattern.matcher("good").programSize())
+        .isEqualTo(programSize);
     Truth.assertWithMessage("Negative matcher program size")
-        .that(pattern.matcher("bad").programSize()).isEqualTo(programSize);
+        .that(pattern.matcher("bad").programSize())
+        .isEqualTo(programSize);
   }
 
   @Test

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -95,7 +95,22 @@ public class MatcherTest {
   }
 
   @Test
+  public void testProgramSize() {
+    // It is a simple delegation, but still test it.
+    // More test cases are covered in PatternTest#testProgramSize.
+    Pattern pattern = Pattern.compile("go+d");
+    int programSize = pattern.programSize();
+    Truth.assertWithMessage("Pattern program size").that(programSize).isGreaterThan(1);
+    Truth.assertWithMessage("Positive matcher program size")
+        .that(pattern.matcher("good").programSize()).isEqualTo(programSize);
+    Truth.assertWithMessage("Negative matcher program size")
+        .that(pattern.matcher("bad").programSize()).isEqualTo(programSize);
+  }
+
+  @Test
   public void testGroupCount() {
+    // It is a simple delegation, but still test it.
+    // More test cases are covered in PatternTest#testGroupCount.
     ApiTestUtils.testGroupCount("(a)(b(c))d?(e)", 4);
   }
 

--- a/javatests/com/google/re2j/PatternTest.java
+++ b/javatests/com/google/re2j/PatternTest.java
@@ -165,8 +165,20 @@ public class PatternTest {
   }
 
   @Test
+  public void testProgramSize() {
+    ApiTestUtils.testProgramSize("", 3);
+    ApiTestUtils.testProgramSize("a", 3);
+    ApiTestUtils.testProgramSize("^", 3);
+    ApiTestUtils.testProgramSize("^$", 4);
+    ApiTestUtils.testProgramSize("a+b", 5);
+    ApiTestUtils.testProgramSize("a+b?", 6);
+    ApiTestUtils.testProgramSize("(a+b)", 7);
+    ApiTestUtils.testProgramSize("a+b.*", 7);
+    ApiTestUtils.testProgramSize("(a+b?)", 8);
+  }
+
+  @Test
   public void testGroupCount() {
-    // It is a simple delegation, but still test it.
     ApiTestUtils.testGroupCount("(.*)ab(.*)a", 2);
     ApiTestUtils.testGroupCount("(.*)(ab)(.*)a", 3);
     ApiTestUtils.testGroupCount("(.*)((a)b)(.*)a", 4);


### PR DESCRIPTION
This PR exposes `Pattern.programSize()` and `Matcher.programSize()` public API.

The program size represents a very approximate measure of a regexp's "cost". Larger numbers are more expensive than smaller numbers.

Similar to the canonical C++ implementation (see [`RE2.ProgramSize()`](https://github.com/google/re2/blob/6dcd83d60f7944926bfd308cc13979fc53dd69ca/re2/re2.h#L326-L328)), re2j will return the program size as the number of instructions of the regex program without making any promises or claims except "larger is more expensive".

Context: The need for this change arose from cross-language projects, such as gRPC and CEL. gRPC needs to configure the maximum size of regex programs in CEL to the same number across all languages. While it's possible in gRPC-Cpp via  CEL-Cpp `options.regex_max_program_size` that uses re2's ProgramSize, CEL-Java doesn't provide the same configuration option simply because the program size is not available in re2j. In Go, the number of instruction is available in Go [`len(syntax.Prog.Inst)`](https://pkg.go.dev/regexp/syntax#Prog.Inst).

Internal ref: go/grpc-cel-integration
CCs:
@ejona86 (grpc-java), @markdroth (grpc)
@l46kok (cel-java), @TristonianJones (cel)