### PR TITLE
Fix parseEscape to support only ASCII values

### DIFF
--- a/java/com/google/re2j/Parser.java
+++ b/java/com/google/re2j/Parser.java
@@ -1344,7 +1344,7 @@ class Parser {
     bigswitch:
     switch (c) {
       default:
-        if (!Utils.isalnum(c)) {
+        if (c <= Unicode.MAX_ASCII && !Utils.isalnum(c)) {
           // Escaped non-word characters are always themselves.
           // PCRE is not quite so rigorous: it accepts things like
           // \q, but we don't.  We once rejected \_, but too many

--- a/javatests/com/google/re2j/ParserTest.java
+++ b/javatests/com/google/re2j/ParserTest.java
@@ -551,6 +551,9 @@ public class ParserTest {
     "(?<foo>bar)(?<foo>baz)",
     "\\x", // https://github.com/google/re2j/issues/103
     "\\xv", // https://github.com/google/re2j/issues/103
+    "^[a-z0-9\\–\\-'‘’]+$",
+    "[\\”\\“]\"",
+    "[\\<\\>\\{\\}\\[\\]\\|\\\”\\%\\~\\#]",
   };
 
   private static final String[] ONLY_PERL = {


### PR DESCRIPTION
![Screenshot 2025-01-31 at 21 20 40](https://github.com/user-attachments/assets/345381d3-7555-46ab-ad5b-518eeaa60026)

Based on [golang parser code](https://cs.opensource.google/go/go/+/refs/tags/go1.23.5:src/regexp/syntax/parse.go;l=1457), one condition was missed, that is why some regex was marked as is valid, when it is not

P.S. in golang `utf8.RuneSelf == 0x80`, but here `Unicode.MAX_ASCII == 0x7f`, that is why `<=` in condition