### PR TITLE
Add Automatic-Module-Name field to META-INF/MANIFEST.MF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,14 @@ dependencies {
   testRuntime "org.slf4j:slf4j-api:1.7.10"
 }
 
+jar {
+    manifest {
+        attributes(
+            'Automatic-Module-Name': 'com.google.re2j'
+        )
+    }
+}
+
 task javadocJar(type: Jar) {
   classifier = 'javadoc'
   from javadoc


### PR DESCRIPTION
Add an Automatic-Module-Name to make the package module friendly, allowing its use in modularised applications in Java 9+.

Partially resolves issue #176