### PR TITLE
Fix handling of `split` when the input is fully matched and the limit is 0

### DIFF
--- a/java/com/google/re2j/Pattern.java
+++ b/java/com/google/re2j/Pattern.java
@@ -272,7 +272,7 @@ public final class Pattern implements Serializable {
       result.add(m.substring(last, m.inputLength()));
     }
 
-    if (limit != 0 || result.isEmpty()) {
+    if (limit != 0 || (result.isEmpty() && !(last == m.inputLength() && last > 0))) {
       result.add(m.substring(last, m.inputLength()));
     }
 

--- a/javatests/com/google/re2j/PatternTest.java
+++ b/javatests/com/google/re2j/PatternTest.java
@@ -162,6 +162,12 @@ public class PatternTest {
     ApiTestUtils.testSplit("x*", "foo", 1, new String[] {"foo"});
     ApiTestUtils.testSplit("x*", "f", 2, new String[] {"f", ""});
     ApiTestUtils.testSplit(":", ":a::b", new String[] {"", "a", "", "b"});
+
+    // From https://github.com/google/re2j/issues/197.
+    // Test split when input is fully matched and limit is 0.
+    ApiTestUtils.testSplit("\\s+", "   ", new String[] {});
+    ApiTestUtils.testSplit("\\s+", "   foo", new String[] {"", "foo"});
+    ApiTestUtils.testSplit("\\s+", "foo   ", new String[] {"foo"});
   }
 
   @Test

--- a/javatests/com/google/re2j/PatternTest.java
+++ b/javatests/com/google/re2j/PatternTest.java
@@ -168,6 +168,7 @@ public class PatternTest {
     ApiTestUtils.testSplit("\\s+", "   ", new String[] {});
     ApiTestUtils.testSplit("\\s+", "   foo", new String[] {"", "foo"});
     ApiTestUtils.testSplit("\\s+", "foo   ", new String[] {"foo"});
+    ApiTestUtils.testSplit("\\s+", "", new String[] {""});
   }
 
   @Test


### PR DESCRIPTION
The specification for limit is

> If `limit == 0`, empty strings that would occur at the end of the array are omitted

https://github.com/google/re2j/issues/197