### PR TITLE
Reset Matcher state on match failure

### DIFF
--- a/java/com/google/re2j/Matcher.java
+++ b/java/com/google/re2j/Matcher.java
@@ -369,6 +369,7 @@ public final class Matcher {
     // From the JDK docs, looks like no.
     boolean ok = pattern.re2().match(matcherInput, startByte, inputLength, anchor, groups, 1);
     if (!ok) {
+      hasMatch = false;
       return false;
     }
     hasMatch = true;

--- a/javatests/com/google/re2j/MatcherTest.java
+++ b/javatests/com/google/re2j/MatcherTest.java
@@ -524,4 +524,48 @@ public class MatcherTest {
       assertEquals("aaa bbb", text.substring(matcher.start(), matcher.end()));
     }
   }
+
+  @Test
+  public void testStateResetOnFailure() {
+    {
+      Matcher m = Pattern.compile("abc").matcher("abc");
+      assertTrue(m.find());
+      assertEquals("abc", m.group());
+
+      // Subsequent find() fails
+      assertFalse(m.find());
+      try {
+        m.group();
+        fail("Should have thrown IllegalStateException");
+      } catch (IllegalStateException expected) {
+        // Expected
+      }
+      try {
+        m.start();
+        fail("Should have thrown IllegalStateException");
+      } catch (IllegalStateException expected) {
+        // Expected
+      }
+      try {
+        m.end();
+        fail("Should have thrown IllegalStateException");
+      } catch (IllegalStateException expected) {
+        // Expected
+      }
+    }
+
+    {
+      // Test matches() then find()
+      Matcher m = Pattern.compile("([1-5][0-9]{2})-([1-5][0-9]{2})").matcher("201-299");
+      assertTrue(m.matches());
+      assertEquals("201-299", m.group());
+      assertFalse(m.find()); // should fail
+      try {
+        m.group(1);
+        fail("Should have thrown IllegalStateException");
+      } catch (IllegalStateException expected) {
+        // Expected
+      }
+    }
+  }
 }


### PR DESCRIPTION
Ensure that when a match operation (`find`, `matches`, `lookingAt`) fails, the matcher's hasMatch state is reset to false. This prevents subsequent calls to `group()`, `start()`, `end()` from returning stale match data from previous successful matches, and instead correctly throws `IllegalStateException`.

* Closes https://github.com/google/re2j/issues/200
* Closes https://github.com/google/re2j/issues/201